### PR TITLE
Update the license to match the projects license

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
   - "2.7"
-  - "3.2"
-  - "3.3"
   - "3.4"
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
-  - "nightly" # currently points to 3.6-dev
+  - "3.6"
+  - "3.7"
+  - "3.8-dev"  # 3.8 development branch
+  - "nightly" # nightly build
 # command to install dependencies
 install: "pip install -r test-requirements.txt"
 # command to run tests, we isolate the tests since the Click CLI Runner

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     description='Easy access of environment variables from Python with support for strings, booleans, list, tuples, and dicts.',
     url='https://github.com/bjinwright/envs',
     author='Brian Jinwright',
-    license='GNU GPL v3',
+    license='Apache License 2.0',
     keywords='environment variables',
     extras_require={
         'cli': parse_requirements('requirements_cli.txt'),


### PR DESCRIPTION
Doing a license audit and this library came up as GPL 3 when it had been
moved to apache 2.0 in #1

If this was updated on https://pypi.org that would be amazing.