### PR TITLE
make compatible with click>=8

### DIFF
--- a/envs/util.py
+++ b/envs/util.py
@@ -4,12 +4,12 @@ import json
 import os
 import sys
 
-from click._compat import raw_input
-
 from . import Env, ENVS_RESULT_FILENAME
 
 VAR_TYPES = Env.valid_types.keys()
 
+if sys.version_info >= (3, 0):
+    raw_input = input
 
 def import_util(imp):
     """


### PR DESCRIPTION
Before its removal, `raw_input()` from `click._compat` was just an alias for `input()` on Python 3:
https://github.com/pallets/click/blob/7239794a610f3ccae3aaf8bfe273ac70cc58ff07/src/click/_compat.py#L280

fixes #18 