### PR TITLE
Fix/setup not including readme

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 #Changes
 
+## 1.5
+Fixed setup.py not reading README.md when published to pypi
+
 ## 1.2.4
 
 Added Decimals variable type

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+from pathlib import Path
 
 
 def parse_requirements(filename):
@@ -6,10 +7,14 @@ def parse_requirements(filename):
     lineiter = (line.strip() for line in open(filename))
     return [line for line in lineiter if line and not line.startswith("#")]
 
+parent_dir = Path(__file__).parent
+long_description = (parent_dir / "README.md").read_text()
 
 setup(
     name='envs',
     description='Easy access of environment variables from Python with support for strings, booleans, list, tuples, and dicts.',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url='https://github.com/bjinwright/envs',
     author='Brian Jinwright',
     license='Apache License 2.0',


### PR DESCRIPTION
# Changes
- Made `setup.py` also read the `README.md` in order for Pypi to have a clear description like the one we have here. 
- Updated `HISTORY.md` to reflect this change (1.5)